### PR TITLE
Delay destroy of building and fixes

### DIFF
--- a/src/bin/incremental-society.rs
+++ b/src/bin/incremental-society.rs
@@ -130,7 +130,7 @@ impl<'a> UI<'a> {
                                     let building = data::get_building(&buildings[building_index]);
                                     match engine::destroy(&mut state, region_index, building_index) {
                                         Err(e) => self.set_message(e.description()),
-                                        _ => self.set_message(format!("Destroyed {}", building.name)),
+                                        _ => self.set_message(format!("Destroying {}", building.name)),
                                     }
                                 }
                                 None => self.clear_message(),

--- a/src/data.rs
+++ b/src/data.rs
@@ -115,7 +115,7 @@ lazy_static! {
             "TestEdict",
             Conversion::init(
                 "TestEdict",
-                ConversionLength::Medium,
+                ConversionLength::Short,
                 vec![ResourceAmount::init(ResourceKind::Fuel, 1)],
                 vec![ResourceAmount::init(ResourceKind::Knowledge, 1)],
             ),

--- a/src/engine/build.rs
+++ b/src/engine/build.rs
@@ -36,6 +36,8 @@ pub fn build(state: &mut GameState, building: Building, region_index: usize) -> 
     can_build_in_region(state, region_index)?;
     can_build_building(state, &building)?;
 
+    state.resources.remove_range(&building.build_cost);
+
     let region = state.regions.get_mut(region_index).unwrap();
     region.add_building(building);
     process::recalculate(state);
@@ -57,21 +59,6 @@ mod tests {
         state.regions = vec![];
 
         assert!(build(&mut state, get_building("Test Building"), 0).is_err());
-    }
-
-    #[test]
-    fn build_valid_building() {
-        let mut state = process::init_empty_game_state();
-        state.regions = vec![Region::init_with_buildings("First Region", vec![get_building("Test Building")])];
-        state.resources[ResourceKind::Fuel] = 20;
-        process::recalculate(&mut state);
-
-        let old_storage = state.derived_state.storage[ResourceKind::Fuel];
-
-        build(&mut state, get_building("Test Building"), 0).unwrap();
-
-        assert_eq!(2, state.buildings().len());
-        assert_ne!(old_storage, state.derived_state.storage[ResourceKind::Fuel]);
     }
 
     #[test]
@@ -112,5 +99,24 @@ mod tests {
             "Unable to build Test Immortal",
             build(&mut state, get_building("Test Immortal"), 1).unwrap_err().description()
         );
+    }
+
+    #[test]
+    fn start_building_but_empty_before_finished() {}
+
+    #[test]
+    fn build_valid_building() {
+        let mut state = process::init_empty_game_state();
+        state.regions = vec![Region::init_with_buildings("First Region", vec![get_building("Test Building")])];
+        state.resources[ResourceKind::Fuel] = 20;
+        process::recalculate(&mut state);
+
+        let old_storage = state.derived_state.storage[ResourceKind::Fuel];
+
+        build(&mut state, get_building("Test Building"), 0).unwrap();
+
+        assert_eq!(10, state.resources[ResourceKind::Fuel]);
+        assert_eq!(2, state.buildings().len());
+        assert_ne!(old_storage, state.derived_state.storage[ResourceKind::Fuel]);
     }
 }

--- a/src/engine/build.rs
+++ b/src/engine/build.rs
@@ -102,9 +102,6 @@ mod tests {
     }
 
     #[test]
-    fn start_building_but_empty_before_finished() {}
-
-    #[test]
     fn build_valid_building() {
         let mut state = process::init_empty_game_state();
         state.regions = vec![Region::init_with_buildings("First Region", vec![get_building("Test Building")])];

--- a/src/engine/destroy.rs
+++ b/src/engine/destroy.rs
@@ -28,7 +28,7 @@ pub fn can_destroy_building(state: &GameState, region_index: usize, building_ind
         .iter()
         .any(|x| if let DelayedAction::Destroy(_, _) = x.action { true } else { false })
     {
-        return Err(EngineError::init(format!("Unable to destroy due to another destruction taking place already.")));
+        return Err(EngineError::init("Unable to destroy due to another destruction taking place already."));
     }
 
     Ok(())

--- a/src/engine/destroy.rs
+++ b/src/engine/destroy.rs
@@ -113,6 +113,11 @@ mod tests {
         let old_storage = state.derived_state.storage[ResourceKind::Food];
         assert!(destroy(&mut state, 1, 0).is_ok());
 
+        for _ in 0..DESTROY_LENGTH {
+            assert_eq!(3, state.buildings().len());
+            process::process_tick(&mut state);
+        }
+
         assert_eq!(2, state.buildings().len());
         assert_ne!(old_storage, state.derived_state.storage[ResourceKind::Food]);
     }

--- a/src/engine/disaster.rs
+++ b/src/engine/disaster.rs
@@ -1,7 +1,7 @@
 use std::cmp;
 
 use super::destroy;
-use crate::state::{DelayedAction, GameState, ResourceKind, Waiter, NUM_RESOURCES};
+use crate::state::{DelayedAction, GameState, ResourceKind, NUM_RESOURCES};
 
 use rand::prelude::*;
 

--- a/src/engine/disaster.rs
+++ b/src/engine/disaster.rs
@@ -1,7 +1,7 @@
 use std::cmp;
 
 use super::destroy;
-use crate::state::{GameState, ResourceKind, NUM_RESOURCES};
+use crate::state::{DelayedAction, GameState, ResourceKind, Waiter, NUM_RESOURCES};
 
 use rand::prelude::*;
 
@@ -49,6 +49,18 @@ pub fn disaster(state: &mut GameState) {
     }
 
     state.resources[ResourceKind::Instability] = 0;
+
+    // Cancel any buildings being destroyed, as they may already be gone and we'll kill the wrong building
+    let actions_to_cancel: Vec<usize> = state
+        .actions
+        .iter()
+        .enumerate()
+        .filter_map(|(i, x)| if let DelayedAction::Destroy(_, _) = x.action { Some(i) } else { None })
+        .collect();
+
+    for i in actions_to_cancel.iter().rev() {
+        state.actions.remove(*i);
+    }
 }
 
 pub fn invoke_disaster_if_needed(state: &mut GameState) -> Option<&'static str> {
@@ -64,6 +76,7 @@ pub fn invoke_disaster_if_needed(state: &mut GameState) -> Option<&'static str> 
 mod tests {
     use super::{super::process, *};
     use crate::data::get_building;
+    use crate::engine::destroy;
     use crate::state::Region;
 
     #[test]
@@ -125,6 +138,16 @@ mod tests {
         state.resources[ResourceKind::Instability] = 100;
         disaster(&mut state);
         assert_eq!(0, state.resources[ResourceKind::Instability]);
+    }
+
+    #[test]
+    fn disaster_cancels_any_buildings_to_be_destroyed() {
+        let mut state = process::init_empty_game_state();
+        state.resources[ResourceKind::Instability] = 100;
+        state.regions.push(Region::init_with_buildings("Region", vec![get_building("Empty Building")]));
+        destroy(&mut state, 0, 0).unwrap();
+        disaster(&mut state);
+        assert!(state.action_with_name("Destroy Empty Building").is_none());
     }
 
     #[test]

--- a/src/engine/disaster.rs
+++ b/src/engine/disaster.rs
@@ -44,8 +44,7 @@ pub fn disaster(state: &mut GameState) {
 
             let (region_index, building_index) = *all_buildings.get(index_to_destroy).unwrap();
 
-            // Ignore buildings unable to be destroy
-            let _ = destroy(state, region_index, building_index);
+            destroy::apply_destroy(state, region_index, building_index);
         }
     }
 

--- a/src/engine/process.rs
+++ b/src/engine/process.rs
@@ -1,4 +1,5 @@
 use super::conversions;
+use super::destroy;
 use super::DerivedState;
 use crate::data;
 use crate::state::{DelayedAction, GameState, Region, ResourceTotal};
@@ -24,6 +25,8 @@ fn apply_actions(state: &mut GameState) {
                     conversions::apply_convert(state, "Sustain Population");
                 }
             }
+            DelayedAction::Build() => {}
+            DelayedAction::Destroy(region_index, building_index) => destroy::apply_destroy(state, *region_index, *building_index),
         }
     }
 }

--- a/src/engine/process.rs
+++ b/src/engine/process.rs
@@ -1,5 +1,6 @@
 use super::conversions;
 use super::destroy;
+use super::edict;
 use super::DerivedState;
 use crate::data;
 use crate::state::{DelayedAction, GameState, Region, ResourceTotal};
@@ -14,7 +15,7 @@ fn apply_actions(state: &mut GameState) {
     let fired_actions = super::actions::tick_actions(&mut state.actions);
     for action in fired_actions.iter() {
         match action {
-            DelayedAction::Edict(name) => conversions::apply_convert(state, name),
+            DelayedAction::Edict(name) => edict::apply_edict(state, name),
             DelayedAction::Conversion(name) => {
                 for _ in 0..*state.derived_state.conversions.get(name).unwrap() {
                     conversions::apply_convert(state, name);

--- a/src/state/actions.rs
+++ b/src/state/actions.rs
@@ -5,6 +5,8 @@ pub enum DelayedAction {
     Edict(String),
     Conversion(String),
     SustainPops(),
+    Build(),
+    Destroy(usize, usize),
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
- Bug: Able to destroy multiple buildings at same time, causing crashes:
- Bug: Disaster could destroy buildings in flight for destruction and thus kill the wrong ones
- Bug: Edicts don't remove cost right away, only later when it can be gone
- Bug: Building building did not spend resources 