### PR TITLE
More upgrade work

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,5 @@
 ## Todo
 
-
-- Upgrades can affects conversion (Hunting uses tool to increase yield)
-- Upgrades can affect building and conversion at same time
 - Upgrades have built in cost instead of a global default to enable and disable
 - Remove duplication around .format(", ")
 - Gameplay pass through middle stone age

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,5 @@
 ## Todo
 
-- Upgrades have built in cost instead of a global default to enable and disable
 - Remove duplication around .format(", ")
 - Gameplay pass through middle stone age
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,20 +1,31 @@
 ## Todo
 
+
+- Upgrades can affects conversion (Hunting uses tool to increase yield)
+- Upgrades can affect building and conversion at same time
+- Upgrades have built in cost instead of a global default to enable and disable
 - Remove duplication around .format(", ")
 - Gameplay pass through middle stone age
 
 - Research 1 of 3
 - Gameplay pass through late stone age
 
+## QOL
+
+- Replace building function
+
+
 ## Longer Term
 
 - Regions Resources
 - Random regions
 - Buildings that require resources
-- Bonus base yield (fixed and %) for conversions
 - Pop growth over time
+- Dig out tech ideas from similar games (Civ 4-6, Egypt Game, Endless Legend, Empire Earth 2, Rise of Nations)
+- Stability and pop growth are resources, and have a midline values. Various effects can push them up/down but will return over time
 
 ## Ideas
 
 - Infrastructure bonus for goods, and max per tech
 - Morale in each region? Lose regions if conquered or rebel?
+- Card View for items

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+blacklisted-names = ["implicit_hasher"]

--- a/src/engine/conversions.rs
+++ b/src/engine/conversions.rs
@@ -1,10 +1,9 @@
 use std::collections::HashSet;
 
-use super::data::get_conversion;
 use crate::state::{DelayedAction, GameState, Waiter, SUSTAIN_POP_DURATION};
 
 pub fn apply_convert(state: &mut GameState, name: &str) {
-    get_conversion(name).convert(&mut state.resources);
+    state.derived_state.find_conversion(name).convert(&mut state.resources);
 }
 
 // There is a modeling problem the engine conversion code needs to handle:
@@ -36,7 +35,7 @@ pub fn sync_building_to_conversions(state: &mut GameState) {
     }
 
     for not_started in active_conversions.keys().filter(|x| !in_flight.contains(*x)) {
-        let conversion = get_conversion(not_started);
+        let conversion = state.derived_state.find_conversion(not_started);
         let action = Waiter::init_repeating(not_started, conversion.tick_length(), DelayedAction::Conversion(not_started.to_string()));
         state.actions.push(action);
     }

--- a/src/engine/data.rs
+++ b/src/engine/data.rs
@@ -143,6 +143,7 @@ lazy_static! {
         m.insert(
             "Stability Building",
             Building::init("Stability Building").with_storage(vec![
+                ResourceAmount::init(ResourceKind::Food, 10),
                 ResourceAmount::init(ResourceKind::Knowledge, 10),
                 ResourceAmount::init(ResourceKind::Instability, 10),
             ]),
@@ -221,6 +222,15 @@ lazy_static! {
             ),
         );
 
+        m.insert(
+            "TestConversionUpgrade",
+            Upgrade::init(
+                "TestConversionUpgrade",
+                vec![UpgradeActions::ChangeConversionOutput(ResourceAmount::init(ResourceKind::Knowledge, 1))],
+                vec!["TestChop".to_owned()],
+            ),
+        );
+
         m.insert("TestOtherUpgrade", Upgrade::init("TestOtherUpgrade", vec![], vec![]));
 
         m.insert(
@@ -234,6 +244,10 @@ lazy_static! {
 
 pub fn get_conversion(name: &str) -> Conversion {
     CONVERSIONS[name].clone()
+}
+
+pub fn get_conversion_names() -> Vec<String> {
+    CONVERSIONS.keys().map(|x| (*x).to_string()).collect()
 }
 
 pub fn get_building(name: &str) -> Building {

--- a/src/engine/data.rs
+++ b/src/engine/data.rs
@@ -210,7 +210,8 @@ lazy_static! {
                 "TestUpgrade",
                 vec![UpgradeActions::AddBuildingConversion("TestChop".to_owned())],
                 vec!["Test Building".to_owned()],
-            ),
+            )
+            .with_cost(vec![ResourceAmount::init(ResourceKind::Knowledge, 25)]),
         );
 
         m.insert(
@@ -219,7 +220,8 @@ lazy_static! {
                 "TestEdictUpgrade",
                 vec![UpgradeActions::ChangeEdictLength(ConversionLength::Long)],
                 vec!["TestEdict".to_owned()],
-            ),
+            )
+            .with_cost(vec![ResourceAmount::init(ResourceKind::Knowledge, 25)]),
         );
 
         m.insert(
@@ -228,7 +230,8 @@ lazy_static! {
                 "TestConversionUpgrade",
                 vec![UpgradeActions::ChangeConversionOutput(ResourceAmount::init(ResourceKind::Knowledge, 1))],
                 vec!["TestChop".to_owned()],
-            ),
+            )
+            .with_cost(vec![ResourceAmount::init(ResourceKind::Knowledge, 25)]),
         );
 
         m.insert(
@@ -241,7 +244,8 @@ lazy_static! {
                     UpgradeActions::ChangeConversionOutput(ResourceAmount::init(ResourceKind::Knowledge, 1)),
                 ],
                 vec!["Test Building".to_owned(), "TestEdict".to_owned(), "TestChop".to_owned()],
-            ),
+            )
+            .with_cost(vec![ResourceAmount::init(ResourceKind::Knowledge, 25)]),
         );
 
         m.insert("TestOtherUpgrade", Upgrade::init("TestOtherUpgrade", vec![], vec![]));

--- a/src/engine/data.rs
+++ b/src/engine/data.rs
@@ -231,6 +231,19 @@ lazy_static! {
             ),
         );
 
+        m.insert(
+            "TestMultiUpgrade",
+            Upgrade::init(
+                "TestMultiUpgrade",
+                vec![
+                    UpgradeActions::AddBuildingConversion("TestChop".to_owned()),
+                    UpgradeActions::ChangeEdictLength(ConversionLength::Long),
+                    UpgradeActions::ChangeConversionOutput(ResourceAmount::init(ResourceKind::Knowledge, 1)),
+                ],
+                vec!["Test Building".to_owned(), "TestEdict".to_owned(), "TestChop".to_owned()],
+            ),
+        );
+
         m.insert("TestOtherUpgrade", Upgrade::init("TestOtherUpgrade", vec![], vec![]));
 
         m.insert(

--- a/src/engine/derived_state.rs
+++ b/src/engine/derived_state.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
-pub use super::upgrade::{available_to_build, available_to_invoke, available_to_research, available_to_upgrade};
-pub use crate::state::{Building, Edict, GameState, Research, ResourceTotal, Upgrade};
+pub use super::upgrade::{available_to_build, available_to_invoke, available_to_research, available_to_upgrade, current_conversions};
+pub use crate::state::{Building, Conversion, Edict, GameState, Research, ResourceTotal, Upgrade};
 
 use itertools::Itertools;
 
@@ -16,6 +16,7 @@ pub struct DerivedState {
     pub available_edicts: Vec<Edict>,
     pub available_research: Vec<Research>,
     pub available_upgrade: Vec<Upgrade>,
+    pub all_conversions: Vec<Conversion>,
 }
 
 impl DerivedState {
@@ -30,6 +31,7 @@ impl DerivedState {
             available_edicts: vec![],
             available_research: vec![],
             available_upgrade: vec![],
+            all_conversions: vec![],
         }
     }
 
@@ -44,6 +46,7 @@ impl DerivedState {
             available_edicts: available_to_invoke(state),
             available_research: available_to_research(state),
             available_upgrade: available_to_upgrade(state),
+            all_conversions: current_conversions(state),
         }
     }
 
@@ -101,6 +104,10 @@ impl DerivedState {
 
     pub fn find_upgrade(&self, name: &str) -> &Upgrade {
         self.available_upgrade.iter().filter(|x| x.name == name).nth(0).unwrap()
+    }
+
+    pub fn find_conversion(&self, name: &str) -> &Conversion {
+        self.all_conversions.iter().filter(|x| x.name == name).nth(0).unwrap()
     }
 }
 

--- a/src/engine/upgrade.rs
+++ b/src/engine/upgrade.rs
@@ -1,8 +1,9 @@
 use std::collections::{HashMap, HashSet};
 
-use super::{die, process, EngineError};
-use crate::engine::data::{get_building, get_building_names, get_edict, get_edict_names, get_research, get_research_names, get_upgrade, get_upgrade_names};
-use crate::state::{Building, DelayedAction, Edict, GameState, Research, ResourceAmount, Upgrade, UpgradeActions, Waiter};
+use super::{process, EngineError};
+use crate::engine::data::{get_building, get_conversion, get_edict, get_research, get_upgrade};
+use crate::engine::data::{get_building_names, get_conversion_names, get_edict_names, get_research_names, get_upgrade_names};
+use crate::state::{Building, Conversion, DelayedAction, Edict, GameState, Research, ResourceAmount, Upgrade, UpgradeActions, Waiter};
 use crate::state::{COST_PER_UPGRADE, MAX_UPGRADES, UPGRADE_LENGTH};
 
 pub fn can_apply_upgrades(state: &GameState, upgrades: &[Upgrade]) -> Result<(), EngineError> {

--- a/src/engine/upgrade.rs
+++ b/src/engine/upgrade.rs
@@ -365,6 +365,18 @@ mod tests {
     }
 
     #[test]
+    fn upgrade_affects_multiple_items_differently() {
+        let mut state = init_empty_game_state();
+        state.regions = vec![Region::init_with_buildings("First Region", vec![get_test_building("Test Building").clone()])];
+        state.upgrades.insert("TestMultiUpgrade".to_string());
+        recalculate(&mut state);
+
+        assert_eq!(2, state.buildings()[0].conversions.len());
+        assert_eq!(2, state.derived_state.find_conversion("TestChop").output.len());
+        assert_eq!(ConversionLength::Long, state.derived_state.find_edict("TestEdict").conversion.length);
+    }
+
+    #[test]
     fn apply_research_allow_up_to_cap_selections() {
         // If changes, test need changes
         assert_eq!(2, MAX_UPGRADES);

--- a/src/engine/upgrade.rs
+++ b/src/engine/upgrade.rs
@@ -146,6 +146,7 @@ fn apply_building_upgrade(building: &mut Building, upgrade: &UpgradeActions) {
     }
 }
 
+#[allow(clippy::single_match)]
 fn apply_edict_upgrade(edict: &mut Edict, upgrade: &UpgradeActions) {
     match upgrade {
         UpgradeActions::ChangeEdictLength(length) => edict.conversion.length = *length,

--- a/src/state/constants.rs
+++ b/src/state/constants.rs
@@ -1,10 +1,7 @@
-use super::{ResourceKind, ResourceQuantity};
-
 pub const BUILD_LENGTH: u32 = 30 * 8;
 pub const UPGRADE_LENGTH: u32 = 30 * 12;
 pub const SUSTAIN_POP_DURATION: u32 = 80;
 pub const DESTROY_LENGTH: u32 = 30 * 5;
-pub const REGION_BUILDING_COUNT: usize = 2;
 pub const RESEARCH_LENGTH: u32 = 30 * 8;
 
 pub const SHORT_CONVERSION: u32 = 50;
@@ -12,6 +9,5 @@ pub const MEDIUM_CONVERSION: u32 = 100;
 pub const LONG_CONVERSION: u32 = 150;
 pub const EPIC_CONVERSION: u32 = 300;
 
-// Use tuple instead of ResourceAmount as structs not allows constants
-pub const COST_PER_UPGRADE: [(ResourceKind, ResourceQuantity); 1] = [(ResourceKind::Knowledge, 25)];
 pub const MAX_UPGRADES: usize = 2;
+pub const REGION_BUILDING_COUNT: usize = 2;

--- a/src/state/upgrade.rs
+++ b/src/state/upgrade.rs
@@ -35,6 +35,7 @@ pub struct Upgrade {
     pub upgrades: Vec<UpgradeActions>,
     pub items_upgraded: Vec<String>,
     pub research: HashSet<String>,
+    pub cost: Vec<ResourceAmount>,
 }
 
 impl Upgrade {
@@ -48,11 +49,17 @@ impl Upgrade {
             upgrades,
             items_upgraded,
             research: HashSet::new(),
+            cost: vec![],
         }
     }
 
     pub fn with_research(mut self, research: Vec<&str>) -> Upgrade {
         self.research = research.iter().map(|x| (*x).to_owned()).collect();
+        self
+    }
+
+    pub fn with_cost(mut self, cost: Vec<ResourceAmount>) -> Upgrade {
+        self.cost = cost;
         self
     }
 

--- a/src/state/upgrade.rs
+++ b/src/state/upgrade.rs
@@ -10,6 +10,9 @@ pub enum UpgradeActions {
     AddBuildingConversion(String),
     AddBuildingStorage(ResourceAmount),
     ChangeEdictLength(ConversionLength),
+    ChangeConversionLength(ConversionLength),
+    ChangeConversionInput(ResourceAmount),
+    ChangeConversionOutput(ResourceAmount),
 }
 
 impl UpgradeActions {
@@ -19,6 +22,9 @@ impl UpgradeActions {
             UpgradeActions::AddBuildingConversion(name) => format!("Adds {} conversion to building", name),
             UpgradeActions::AddBuildingStorage(storage) => format!("Adds {:?} storage", storage),
             UpgradeActions::ChangeEdictLength(length) => format!("Changes edict length to {:?}", length),
+            UpgradeActions::ChangeConversionLength(length) => format!("Changes conversion length to {:?}", length),
+            UpgradeActions::ChangeConversionInput(input) => format!("Adds {:?} to required conversion input", input),
+            UpgradeActions::ChangeConversionOutput(output) => format!("Adds {:?} to required conversion output", output),
         }
     }
 }


### PR DESCRIPTION
- Remove global resource code and use a per-upgrade as other items do
- Upgrades can affect multiple items at same time
- Bug: Upgrades did not consume cost. 
- Add conversion upgrade test
- Move conversions to derive state. 
- Optimize some code in upgrades